### PR TITLE
Introduce non-stale price requirement for minting/liquidating 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "ethereum-waffle": "^3.3.0",
         "ethers": "^5.5.1",
         "fs-extra": "^10.0.0",
-        "hardhat": "^2.8.3",
+        "hardhat": "v2.9.2",
         "hardhat-deploy": "^0.9.8",
         "hardhat-gas-reporter": "^1.0.4",
         "husky": "^6.0.0",

--- a/src/contracts/Kresko.sol
+++ b/src/contracts/Kresko.sol
@@ -120,6 +120,9 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice The minimum USD value of an individual synthetic asset debt position.
     FixedPoint.Unsigned public minimumDebtValue;
 
+    /// @notice The number of seconds until a price is considered stale
+    uint256 public secondsUntilStalePrice;
+
     /* ===== General state - Collateral Assets ===== */
 
     /// @notice Mapping of collateral asset token address to information on the collateral asset.
@@ -334,6 +337,12 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     event MinimumDebtValueUpdated(uint256 indexed minimumDebtValue);
 
     /**
+     * @notice Emitted when the seconds until stale price value is updated.
+     * @param secondsUntilStalePrice The new seconds until stale price value.
+     */
+    event SecondsUntilStalePriceUpdated(uint256 indexed secondsUntilStalePrice);
+
+    /**
      * ==================================================
      * =================== Modifiers ====================
      * ==================================================
@@ -389,6 +398,17 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     }
 
     /**
+     * @notice Reverts if a Kresko asset's price is stale
+     * @param _kreskoAsset The address of the Kresko asset.
+     */
+    modifier kreskoAssetPriceNotStale(address _kreskoAsset) {
+        uint256 priceTimestamp = uint256(kreskoAssets[_kreskoAsset].oracle.latestTimestamp());
+        // Include a buffer as block.timestamp can be manipulated up to 15 seconds.
+        require(block.timestamp < priceTimestamp+secondsUntilStalePrice, "KR: stale price");
+        _;
+    }
+
+    /**
      * @notice Reverts if the symbol of a Kresko asset already exists within the protocol.
      * @param _kreskoAsset The address of the Kresko asset.
      * @param _symbol The symbol of the Kresko asset.
@@ -430,7 +450,8 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         address _feeRecipient,
         uint256 _liquidationIncentiveMultiplier,
         uint256 _minimumCollateralizationRatio,
-        uint256 _minimumDebtValue
+        uint256 _minimumDebtValue,
+        uint256 _secondsUntilStalePrice
     ) external initializer {
         // Set msg.sender as the owner.
         __Ownable_init();
@@ -439,6 +460,7 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         updateLiquidationIncentiveMultiplier(_liquidationIncentiveMultiplier);
         updateMinimumCollateralizationRatio(_minimumCollateralizationRatio);
         updateMinimumDebtValue(_minimumDebtValue);
+        updateSecondsUntilStalePrice(_secondsUntilStalePrice);
     }
 
     /**
@@ -575,7 +597,12 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         address _account,
         address _kreskoAsset,
         uint256 _amount
-    ) external nonReentrant kreskoAssetExistsAndMintable(_kreskoAsset) ensureTrustedCallerWhen(_account != msg.sender) {
+    ) external
+        nonReentrant
+        kreskoAssetExistsAndMintable(_kreskoAsset)
+        kreskoAssetPriceNotStale(_kreskoAsset)
+        ensureTrustedCallerWhen(_account != msg.sender)
+    {
         require(_amount > 0, "KR: 0-mint");
 
         // Enforce synthetic asset's maximum market capitalization limit
@@ -1011,6 +1038,15 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         require(_minimumDebtValue <= MAX_DEBT_VALUE, "KR: debtValue > max");
         minimumDebtValue = FixedPoint.Unsigned(_minimumDebtValue);
         emit MinimumDebtValueUpdated(_minimumDebtValue);
+    }
+
+    /**
+     * @dev Updates the contract's seconds until stale price value
+     * @param _secondsUntilStalePrice The new seconds until stale price.
+     */
+    function updateSecondsUntilStalePrice(uint256 _secondsUntilStalePrice) public onlyOwner {
+        secondsUntilStalePrice = _secondsUntilStalePrice;
+        emit SecondsUntilStalePriceUpdated(_secondsUntilStalePrice);
     }
 
     /**

--- a/src/contracts/Kresko.sol
+++ b/src/contracts/Kresko.sol
@@ -721,6 +721,9 @@ contract Kresko is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         require(collateralAssets[_collateralAssetToSeize].exists, "KR: !collateralExists");
         require(_repayAmount > 0, "KR: 0-repay");
 
+        uint256 priceTimestamp = uint256(kreskoAssets[_repayKreskoAsset].oracle.latestTimestamp());
+        require(block.timestamp < priceTimestamp+secondsUntilStalePrice, "KR: stale price");
+
         // Borrower cannot liquidate themselves
         require(msg.sender != _account, "KR: self liquidation");
 

--- a/src/tasks/kresko/deployKresko.ts
+++ b/src/tasks/kresko/deployKresko.ts
@@ -61,6 +61,7 @@ task("deploy:kresko")
                 feeRecipient: await Kresko.feeRecipient(),
                 minimumCollateralizationRatio: formatEther(await Kresko.minimumCollateralizationRatio()),
                 minimumDebtValue: formatEther(await Kresko.minimumDebtValue()),
+                secondsUntilPriceStale: await Kresko.secondsUntilStalePrice(),
             };
             const contracts = {
                 ProxyAdmin: ProxyAdmin.address,

--- a/src/test/Kresko.ts
+++ b/src/test/Kresko.ts
@@ -14,6 +14,7 @@ import {
     LIQUIDATION_INCENTIVE,
     MINIMUM_COLLATERALIZATION_RATIO,
     MINIMUM_DEBT_VALUE,
+    SECONDS_UNTIL_PRICE_STALE,
     NAME_ONE,
     NAME_TWO,
     ONE,
@@ -74,6 +75,7 @@ describe("Kresko", function () {
                     LIQUIDATION_INCENTIVE,
                     MINIMUM_COLLATERALIZATION_RATIO,
                     MINIMUM_DEBT_VALUE,
+                    SECONDS_UNTIL_PRICE_STALE,
                 ),
             ).to.be.revertedWith("Initializable: contract is already initialized");
         });

--- a/src/test/Time.ts
+++ b/src/test/Time.ts
@@ -50,7 +50,6 @@ describe("Time", function () {
         ); // kFactor = 1, price = $250
     });
 
-
     it("should not allow minting of Kresko assets when price is stale", async function () {
         // Attempt initial mint with fresh price
         const kreskoAssetAddress = this.kreskoAssetInfo.kreskoAsset.address;

--- a/src/test/Time.ts
+++ b/src/test/Time.ts
@@ -1,0 +1,100 @@
+import hre from "hardhat";
+import { expect } from "chai";
+
+import {
+    CollateralAssetInfo,
+    addNewKreskoAssetWithOraclePrice,
+    deployAndWhitelistCollateralAsset,
+    NAME_TWO,
+    setupTests,
+    SYMBOL_TWO,
+    MARKET_CAP_ONE_MILLION,
+    toFixedPoint,
+} from "@utils";
+
+describe("Time", function () {
+
+    beforeEach(async function () {
+        const { signers, kresko } = await setupTests();
+        this.signers = signers;
+        this.Kresko = kresko;
+
+        // Deploy and whitelist collateral asset
+        this.initialUserCollateralBalance = 1000;
+        this.collateralAssetInfos = (await Promise.all<CollateralAssetInfo>([
+            deployAndWhitelistCollateralAsset(this.Kresko, 1, 150, 18),
+        ])) as CollateralAssetInfo[];
+
+        for (const collateralAssetInfo of this.collateralAssetInfos as CollateralAssetInfo[]) {
+            // Give userOne a balance of 1000 for each collateral asset.
+            await collateralAssetInfo.collateralAsset.setBalanceOf(
+                this.signers.userOne.address,
+                collateralAssetInfo.fromDecimal(this.initialUserCollateralBalance),
+            );
+
+            // userOne deposits entire balance as collateral
+            await this.Kresko.connect(this.signers.userOne).depositCollateral(
+                this.signers.userOne.address,
+                collateralAssetInfo.collateralAsset.address,
+                collateralAssetInfo.fromDecimal(this.initialUserCollateralBalance),
+            );
+        }
+
+        this.kreskoAssetInfo = await addNewKreskoAssetWithOraclePrice(
+            this.Kresko,
+            NAME_TWO,
+            SYMBOL_TWO,
+            1,
+            1,
+            MARKET_CAP_ONE_MILLION,
+        ); // kFactor = 1, price = $250
+    });
+
+
+    it("should not allow minting of Kresko assets when price is stale", async function () {
+        // Attempt initial mint with fresh price
+        const kreskoAssetAddress = this.kreskoAssetInfo.kreskoAsset.address;
+        const mintAmount = toFixedPoint(100);
+        await this.Kresko.connect(this.signers.userOne).mintKreskoAsset(
+            this.signers.userOne.address,
+            kreskoAssetAddress,
+            mintAmount,
+        );
+
+        // Confirm the amount minted is recorded for the user
+        const amountMinted = await this.Kresko.kreskoAssetDebt(
+            this.signers.userOne.address,
+            kreskoAssetAddress,
+        );
+        expect(amountMinted).to.equal(mintAmount);
+
+        // Update the block time to be 1 second later than allowed
+        const blockNumber = await hre.ethers.provider.getBlockNumber();
+        const blockTimestamp = (await hre.ethers.provider.getBlock(blockNumber)).timestamp;
+        const secsUntilStale = await this.Kresko.secondsUntilStalePrice();
+        const fastForwardSeconds =  Number(secsUntilStale) + 1;
+        const newTimestamp = blockTimestamp + fastForwardSeconds;
+        await hre.ethers.provider.send('evm_mine', [newTimestamp]);
+
+        // Confirm that the block time has been updated
+        const secondBlockNumber = await hre.ethers.provider.getBlockNumber();
+        const secondBlockTimestamp = (await hre.ethers.provider.getBlock(secondBlockNumber)).timestamp;
+        expect(secondBlockTimestamp).to.equal(blockTimestamp + fastForwardSeconds);
+
+        // Confirm that price is now stale and attempted mint reverts
+        await expect(
+            this.Kresko.connect(this.signers.userOne).mintKreskoAsset(
+                this.signers.userOne.address,
+                kreskoAssetAddress,
+                mintAmount,
+            ),
+        ).to.be.revertedWith("KR: stale price");
+
+        // Confirm no additional amount was minted
+        const newAmountMinted = await this.Kresko.kreskoAssetDebt(
+            this.signers.userOne.address,
+            kreskoAssetAddress,
+        );
+        expect(newAmountMinted).to.equal(amountMinted);
+    });
+});

--- a/src/utils/constuctors.ts
+++ b/src/utils/constuctors.ts
@@ -15,6 +15,7 @@ export const constructors = {
             throw new Error("fee recipient address not set");
         }
         const feeRecipientAddress = ethers.utils.getAddress(feeRecipientAddressStr);
+        const secondsUntilPriceStale = overrides?.secondsUntilPriceStale || process.env.SECONDS_UNTIL_PRICE_STALE;
 
         return {
             burnFee,
@@ -22,6 +23,7 @@ export const constructors = {
             liquidationIncentive,
             minimumCollateralizationRatio,
             minimumDebtValue,
+            secondsUntilPriceStale,
         };
     },
 };

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -24,6 +24,7 @@ export const MINIMUM_COLLATERALIZATION_RATIO = toFixedPoint(1.5); // 150%
 export const CLOSE_FACTOR = toFixedPoint(0.2); // 20%
 export const LIQUIDATION_INCENTIVE = toFixedPoint(1.1); // 110% -> liquidators make 10% on liquidations
 export const MINIMUM_DEBT_VALUE = toFixedPoint(10); // $10
+export const SECONDS_UNTIL_PRICE_STALE = 60;
 export const FEE_RECIPIENT_ADDRESS = "0x0000000000000000000000000000000000000FEE";
 
 export const { deployContract } = waffle;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -34,6 +34,7 @@ declare global {
         liquidationIncentive: BigNumberish;
         minimumCollateralizationRatio: BigNumberish;
         minimumDebtValue: BigNumberish;
+        secondsUntilPriceStale: BigNumberish;
     }
     interface KreskoAssetConstructor {
         name: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,7 +1123,7 @@ __metadata:
     ethers: ^5.5.1
     fs-extra: ^10.0.0
     global: ^4.4.0
-    hardhat: ^2.8.3
+    hardhat: v2.9.2
     hardhat-deploy: ^0.9.8
     hardhat-gas-reporter: ^1.0.4
     husky: ^6.0.0
@@ -1284,6 +1284,19 @@ __metadata:
   version: 6.10.0
   resolution: "@ledgerhq/logs@npm:6.10.0"
   checksum: 6194311890ccc3879fb1371e37a6ca67e7e13ea67199885b15ba8dd1c6613f31fd52a5248bdc541c2d2632aadd099af34524adc34f0e0f94732ba3ff6e3069fe
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-sig-util@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/eth-sig-util@npm:4.0.0"
+  dependencies:
+    ethereumjs-abi: ^0.6.8
+    ethereumjs-util: ^6.2.1
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: 983fc1d4ba2d23d8d87024013edc38660456be978641087fa4c9ca4a1c8ea0cb33e5b6845153e3f8d76adf297d38479fcfd16ed871916fee8814cca05b85b458
   languageName: node
   linkType: hard
 
@@ -1660,6 +1673,15 @@ __metadata:
   dependencies:
     antlr4ts: ^0.5.0-alpha.4
   checksum: fe92710e53b2bb9e8423129ca2984c08723f575eda2e4f83a8e883a741436e5ca0bd36826c10ec553bd72d6fe6abd5178ee291baafdf0bb71eb56ca91e383804
+  languageName: node
+  linkType: hard
+
+"@solidity-parser/parser@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "@solidity-parser/parser@npm:0.14.1"
+  dependencies:
+    antlr4ts: ^0.5.0-alpha.4
+  checksum: 616df6c31007710f2a99f8022fa5917968bbe83293cdc0154ba378aad405c0fc0b7af45cf2c99d159ff0b24b67c7a9bc01f80178d086c705682f2f8c7f771137
   languageName: node
   linkType: hard
 
@@ -4766,6 +4788,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:3.5.3, chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.5.2":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^2.1.8":
   version: 2.1.8
   resolution: "chokidar@npm:2.1.8"
@@ -4786,25 +4827,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: 0c43e89cbf0268ef1e1f41ce8ec5233c7ba022c6f3282c2ef6530e351d42396d389a1148c5a040f291cf1f4083a4c6b2f51dad3f31c726442ea9a337de316bcf
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.5.2":
-  version: 3.5.3
-  resolution: "chokidar@npm:3.5.3"
-  dependencies:
-    anymatch: ~3.1.2
-    braces: ~3.0.2
-    fsevents: ~2.3.2
-    glob-parent: ~5.1.2
-    is-binary-path: ~2.1.0
-    is-glob: ~4.0.1
-    normalize-path: ~3.0.0
-    readdirp: ~3.6.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -5746,7 +5768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
+"debug@npm:4, debug@npm:4.3.3, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
   version: 4.3.3
   resolution: "debug@npm:4.3.3"
   dependencies:
@@ -7019,18 +7041,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eth-sig-util@npm:^2.5.2":
-  version: 2.5.4
-  resolution: "eth-sig-util@npm:2.5.4"
-  dependencies:
-    ethereumjs-abi: 0.6.8
-    ethereumjs-util: ^5.1.1
-    tweetnacl: ^1.0.3
-    tweetnacl-util: ^0.15.0
-  checksum: 727ff2ec7859d9609fa3b43d1652eb40740f075e0196cacd67d5bcf50f8fb17fdbf6f384ad457785684d86a0e8155375aece42ad8393487eb8f665adb640b340
-  languageName: node
-  linkType: hard
-
 "eth-tx-summary@npm:^3.1.2":
   version: 3.2.4
   resolution: "eth-tx-summary@npm:3.2.4"
@@ -7278,7 +7288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0":
+"ethereumjs-util@npm:6.2.1, ethereumjs-util@npm:^6.0.0, ethereumjs-util@npm:^6.1.0, ethereumjs-util@npm:^6.2.0, ethereumjs-util@npm:^6.2.1":
   version: 6.2.1
   resolution: "ethereumjs-util@npm:6.2.1"
   dependencies:
@@ -7469,7 +7479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3":
+"ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3, ethjs-util@npm:^0.1.6":
   version: 0.1.6
   resolution: "ethjs-util@npm:0.1.6"
   dependencies:
@@ -8654,20 +8664,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"glob@npm:^5.0.15":
-  version: 5.0.15
-  resolution: "glob@npm:5.0.15"
-  dependencies:
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: 2 || 3
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: f9742448303460672607e569457f1b57e486a79a985e269b69465834d2075b243378225f65dc54c09fcd4b75e4fb34442aec88f33f8c65fa4abccc8ee2dc2f5d
-  languageName: node
-  linkType: hard
-
-"glob@npm:^7.0.0, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:~7.2.0":
+"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:~7.2.0":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -8678,6 +8675,19 @@ fsevents@~2.1.1:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
+  languageName: node
+  linkType: hard
+
+"glob@npm:^5.0.15":
+  version: 5.0.15
+  resolution: "glob@npm:5.0.15"
+  dependencies:
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: 2 || 3
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: f9742448303460672607e569457f1b57e486a79a985e269b69465834d2075b243378225f65dc54c09fcd4b75e4fb34442aec88f33f8c65fa4abccc8ee2dc2f5d
   languageName: node
   linkType: hard
 
@@ -8949,9 +8959,9 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "hardhat@npm:2.8.3"
+"hardhat@npm:v2.9.2":
+  version: 2.9.2
+  resolution: "hardhat@npm:2.9.2"
   dependencies:
     "@ethereumjs/block": ^3.6.0
     "@ethereumjs/blockchain": ^5.5.0
@@ -8959,12 +8969,14 @@ fsevents@~2.1.1:
     "@ethereumjs/tx": ^3.4.0
     "@ethereumjs/vm": ^5.6.0
     "@ethersproject/abi": ^5.1.2
+    "@metamask/eth-sig-util": ^4.0.0
     "@sentry/node": ^5.18.1
-    "@solidity-parser/parser": ^0.14.0
+    "@solidity-parser/parser": ^0.14.1
     "@types/bn.js": ^5.1.0
     "@types/lru-cache": ^5.1.0
     abort-controller: ^3.0.0
     adm-zip: ^0.4.16
+    aggregate-error: ^3.0.0
     ansi-escapes: ^4.3.0
     chalk: ^2.4.2
     chokidar: ^3.4.0
@@ -8972,7 +8984,6 @@ fsevents@~2.1.1:
     debug: ^4.1.1
     enquirer: ^2.3.0
     env-paths: ^2.2.0
-    eth-sig-util: ^2.5.2
     ethereum-cryptography: ^0.1.2
     ethereumjs-abi: ^0.6.8
     ethereumjs-util: ^7.1.3
@@ -8980,14 +8991,13 @@ fsevents@~2.1.1:
     fp-ts: 1.19.3
     fs-extra: ^7.0.1
     glob: ^7.1.3
-    https-proxy-agent: ^5.0.0
     immutable: ^4.0.0-rc.12
     io-ts: 1.10.4
     lodash: ^4.17.11
     merkle-patricia-tree: ^4.2.2
     mnemonist: ^0.38.0
-    mocha: ^7.2.0
-    node-fetch: ^2.6.0
+    mocha: ^9.2.0
+    p-map: ^4.0.0
     qs: ^6.7.0
     raw-body: ^2.4.1
     resolve: 1.17.0
@@ -8998,11 +9008,12 @@ fsevents@~2.1.1:
     stacktrace-parser: ^0.1.10
     true-case-path: ^2.2.1
     tsort: 0.0.1
+    undici: ^4.14.1
     uuid: ^8.3.2
     ws: ^7.4.6
   bin:
     hardhat: internal/cli/cli.js
-  checksum: 760faf9c91d5c6cb5035bf9e62d14fb52cae6a995b86195457cf1d41a1fb73c4ec1ef9c7e8e033e335495d65265a072ddef4a4b56b1cbaa94c18fc87edf91e16
+  checksum: bbee86d43e85a7a841f8b6a6d7bc6609fa2f052db75cbc131eb40e770744f847ca5ed5211314219c90a375f065c987cfd79e0167bfd84c8b674aa2963c94f1a6
   languageName: node
   linkType: hard
 
@@ -10133,6 +10144,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
+  languageName: node
+  linkType: hard
+
 "is-upper-case@npm:^1.1.0":
   version: 1.1.2
   resolution: "is-upper-case@npm:1.1.2"
@@ -10382,6 +10400,17 @@ fsevents@~2.1.1:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 931d6dddb3589fa272c8273366c6dffa99fd6bd26ac7b70f9bac925c28cb7ae352b964192df84f90ecd7a2ff50ab87e6d58e2148eb19c89aa155c73ed847ab92
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
   languageName: node
   linkType: hard
 
@@ -11264,6 +11293,16 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: ^4.1.0
+    is-unicode-supported: ^0.1.0
+  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
 "log-update@npm:^4.0.0":
   version: 4.0.0
   resolution: "log-update@npm:4.0.0"
@@ -11868,6 +11907,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"minimatch@npm:4.2.1":
+  version: 4.2.1
+  resolution: "minimatch@npm:4.2.1"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: 2b1514e3d0f29a549912f0db7ae7b82c5cab4a8f2dd0369f1c6451a325b3f12b2cf473c95873b6157bb8df183d6cf6db82ff03614b6adaaf1d7e055beccdfd01
+  languageName: node
+  linkType: hard
+
 "minimist-options@npm:4.1.0":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -12039,7 +12087,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"mocha@npm:^7.1.1, mocha@npm:^7.2.0":
+"mocha@npm:^7.1.1":
   version: 7.2.0
   resolution: "mocha@npm:7.2.0"
   dependencies:
@@ -12107,6 +12155,41 @@ fsevents@~2.1.1:
     _mocha: bin/_mocha
     mocha: bin/mocha
   checksum: 4bcf00670580f009f9e20cc596cce5e2434d3562c468da783a8f935e38c4476435f12ecade43341cb8730b9d4987358038e76a075201d4bc51010927d3f8cd7c
+  languageName: node
+  linkType: hard
+
+"mocha@npm:^9.2.0":
+  version: 9.2.2
+  resolution: "mocha@npm:9.2.2"
+  dependencies:
+    "@ungap/promise-all-settled": 1.1.2
+    ansi-colors: 4.1.1
+    browser-stdout: 1.3.1
+    chokidar: 3.5.3
+    debug: 4.3.3
+    diff: 5.0.0
+    escape-string-regexp: 4.0.0
+    find-up: 5.0.0
+    glob: 7.2.0
+    growl: 1.10.5
+    he: 1.2.0
+    js-yaml: 4.1.0
+    log-symbols: 4.1.0
+    minimatch: 4.2.1
+    ms: 2.1.3
+    nanoid: 3.3.1
+    serialize-javascript: 6.0.0
+    strip-json-comments: 3.1.1
+    supports-color: 8.1.1
+    which: 2.0.2
+    workerpool: 6.2.0
+    yargs: 16.2.0
+    yargs-parser: 20.2.4
+    yargs-unparser: 2.0.0
+  bin:
+    _mocha: bin/_mocha
+    mocha: bin/mocha
+  checksum: 4d5ca4ce33fc66627e63acdf09a634e2358c9a00f61de7788b1091b6aad430da04f97f9ecb82d56dc034b623cb833b65576136fd010d77679c03fcea5bc1e12d
   languageName: node
   linkType: hard
 
@@ -12258,6 +12341,15 @@ fsevents@~2.1.1:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: f6246023d5d8313c2c16be05c18cdb189a6de50ab6418b513b34086eda4aabd12866b2cbe435548c760dc43cf11830b26b14b113afde47305398e3345795e433
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:3.3.1":
+  version: 3.3.1
+  resolution: "nanoid@npm:3.3.1"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
   languageName: node
   linkType: hard
 
@@ -15013,6 +15105,15 @@ resolve@1.17.0:
   languageName: node
   linkType: hard
 
+"serialize-javascript@npm:6.0.0":
+  version: 6.0.0
+  resolution: "serialize-javascript@npm:6.0.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
+  languageName: node
+  linkType: hard
+
 "serve-static@npm:1.14.2":
   version: 1.14.2
   resolution: "serve-static@npm:1.14.2"
@@ -16674,7 +16775,7 @@ resolve@1.17.0:
   languageName: node
   linkType: hard
 
-"tweetnacl-util@npm:^0.15.0":
+"tweetnacl-util@npm:^0.15.0, tweetnacl-util@npm:^0.15.1":
   version: 0.15.1
   resolution: "tweetnacl-util@npm:0.15.1"
   checksum: ae6aa8a52cdd21a95103a4cc10657d6a2040b36c7a6da7b9d3ab811c6750a2d5db77e8c36969e75fdee11f511aa2b91c552496c6e8e989b6e490e54aca2864fc
@@ -16987,6 +17088,13 @@ resolve@1.17.0:
   version: 1.9.1
   resolution: "underscore@npm:1.9.1"
   checksum: bee6f587661a6a9ca2f77e611896141e0287af51d8ca6034b11d0d4163ddbdd181a9720078ddbe94d265b7694f4880bc7f4c2ad260cfb8985ee2f9adcf13df03
+  languageName: node
+  linkType: hard
+
+"undici@npm:^4.14.1":
+  version: 4.16.0
+  resolution: "undici@npm:4.16.0"
+  checksum: 5e88c2b3381085e25ed1d1a308610ac7ee985f478ac705af7a8e03213536e10f73ef8dd8d85e6ed38948d1883fa0ae935e04357c317b0f5d3d3c0211d0c8c393
   languageName: node
   linkType: hard
 
@@ -18474,6 +18582,13 @@ resolve@1.17.0:
   version: 6.1.0
   resolution: "workerpool@npm:6.1.0"
   checksum: 519d03a4d008fd95ff9e1a583afe537e6a0eecd8250452044e390db3e1dc4ce91616a8ee6c4bba9a2fda38440c2666664c31b50b5a9fd05cc43c739df54d5781
+  languageName: node
+  linkType: hard
+
+"workerpool@npm:6.2.0":
+  version: 6.2.0
+  resolution: "workerpool@npm:6.2.0"
+  checksum: 3493b4f0ef979a23d2c1583d7ef85f62fc9463cc02f82829d3e7e663b517f8ae9707da0249b382e46ac58986deb0ca2232ee1081713741211bda9254b429c9bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds stale price requirement for minting/liquidations.
- Timestamp can be manipulated by up to 15 seconds, shouldn't be a problem for us if we set up our bounds correctly
- Upgraded to hardhat@2.9
- Added new test `Time.ts` instead of adding to the bloated `Kresko.ts`

Will add a test for liquidation in future work