### PR TITLE
Charge liquidators burn fee

### DIFF
--- a/hardhat-configs/networks.ts
+++ b/hardhat-configs/networks.ts
@@ -101,6 +101,7 @@ export const networks = (mnemonic: string) => ({
         accounts: {
             mnemonic,
         },
+        allowUnlimitedContractSize: true,
         chainId: chainIds.hardhat,
         saveDeployments: true,
         deploy: ["./src/deploy/local"],

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -61,7 +61,6 @@ const config = {
     mocha: {
         timeout: 120000,
     },
-    allowUnlimitedContractSize: true,
 };
 
 export default config;

--- a/src/contracts/test/ExampleFlashLiquidator.sol
+++ b/src/contracts/test/ExampleFlashLiquidator.sol
@@ -148,8 +148,13 @@ contract ExampleFlashLiquidator is IERC3156FlashBorrower {
             false // do not keep debt - we want the profits after repaying this flashloan
         );
 
-        // Withdraw our collateral back = flashloan amount
-        kresko.withdrawCollateral(address(this), address(weth10), flashBalance, 0);
+        // Withdraw our collateral back = remaining deposited weth10 amount
+        uint256 weth10CollateralDepositAmount = kresko.collateralDeposits(address(this), address(weth10));
+        kresko.withdrawCollateral(address(this), address(weth10), weth10CollateralDepositAmount, 0);
+
+        uint256 diff = flashBalance - weth10CollateralDepositAmount;
+        require(diff > 0, "revert");
+        weth10.deposit(diff);
 
         uint256 rewardTokenBalAfter = IERC20(_rewardCollateral).balanceOf(address(this));
 

--- a/src/contracts/test/interfaces/IKresko.sol
+++ b/src/contracts/test/interfaces/IKresko.sol
@@ -87,6 +87,8 @@ interface IKresko {
 
     function kreskoAssetDebt(address, address) external view returns (uint256);
 
+    function collateralDeposits(address, address) external view returns (uint256);
+
     function getAccountMinimumCollateralValue(address _account) external view returns (FixedPoint.Unsigned memory);
 
     function getMinimumCollateralValue(address _krAsset, uint256 _amount)

--- a/src/contracts/test/interfaces/IWETH10.sol
+++ b/src/contracts/test/interfaces/IWETH10.sol
@@ -11,4 +11,6 @@ interface IWETH10 {
     ) external returns (bool);
 
     function balanceOf(address) external view returns (uint256);
+
+    function deposit(uint256 _amount) external;
 }

--- a/src/test/Kresko.ts
+++ b/src/test/Kresko.ts
@@ -2595,7 +2595,7 @@ describe("Kresko", function () {
             });
         });
 
-        describe("#liquidate", function () {
+        describe.only("#liquidate", function () {
             it("should allow unhealthy accounts to be liquidated", async function () {
                 // Change collateral asset's USD value from $20 to $11
                 const oracle = this.collateralAssetInfos[0].oracle;
@@ -2912,8 +2912,8 @@ describe("Kresko", function () {
                     this.collDecimals,
                 );
 
-                // Liquidator collateral deposits in the protocol stay the same
-                expect(liquidatorBalanceInProtocolAfterLiquidation).to.equal(
+                // Liquidator collateral deposits in the protocol is reduced because of the burn fee
+                expect(liquidatorBalanceInProtocolAfterLiquidation).to.be.lessThan(
                     liquidatorBalanceInProtocolBeforeLiquidation,
                 );
 
@@ -2946,8 +2946,10 @@ describe("Kresko", function () {
                     this.collDecimals,
                 );
 
-                // Protocol should receive 5% (MAX_BURN_FEE) from the liquidation
-                expect(feeRecipientBalance).to.be.closeTo(liquidatorProfit / 2, feeRecipientBalance * 0.02);
+                // Protocol should receive 5% (MAX_BURN_FEE) twice from the liquidation as burn fee is paid twice
+                expect(feeRecipientBalance).to.be.closeTo(
+                    liquidatorProfit, feeRecipientBalance * 0.02
+                );
 
                 // Shouldn't be able to liquidate a healthy position anymore
                 await expect(

--- a/src/test/Kresko.ts
+++ b/src/test/Kresko.ts
@@ -2595,7 +2595,7 @@ describe("Kresko", function () {
             });
         });
 
-        describe.only("#liquidate", function () {
+        describe("#liquidate", function () {
             it("should allow unhealthy accounts to be liquidated", async function () {
                 // Change collateral asset's USD value from $20 to $11
                 const oracle = this.collateralAssetInfos[0].oracle;


### PR DESCRIPTION
- Charge liquidators burn fee
- Fix bug where liquidator's krAssetDebt mapping was not correctly reduced in some situations

The following Solvency.ts tests are failing due to the changes and must be rewritten:
```
  2) Solvency
       should repay a single market position back to healthy in a single transaction:

      AssertionError: expected 2354.199203187251 to be below 2137.0368685258964
      + expected - actual

      -2354.199203187251
      +2137.0368685258964
      
      at Context.<anonymous> (src/test/Solvency.ts:807:66)

  3) Solvency
       should cascade liquidations for users with with multiple positions:

      AssertionError: expected 196045.95678355286 to be at most 191101.34819128603
      + expected - actual

      -196045.95678355286
      +191101.34819128603
      
      at Context.<anonymous> (src/test/Solvency.ts:937:45)
```