### PR TITLE
revert direct erc4626 mints like the rest

### DIFF
--- a/src/contracts/core/common/Errors.sol
+++ b/src/contracts/core/common/Errors.sol
@@ -60,6 +60,7 @@ library Errors {
     error NOT_SWAPPABLE_KRASSET(ID);
     error IDENTICAL_ASSETS(ID);
     error WITHDRAW_NOT_SUPPORTED();
+    error MINT_NOT_SUPPORTED();
     error DEPOSIT_NOT_SUPPORTED();
     error REDEEM_NOT_SUPPORTED();
     error NATIVE_TOKEN_DISABLED(ID);

--- a/src/contracts/core/kresko-asset/KreskoAssetAnchor.sol
+++ b/src/contracts/core/kresko-asset/KreskoAssetAnchor.sol
@@ -73,13 +73,6 @@ contract KreskoAssetAnchor is ERC4626Upgradeable, IKreskoAssetAnchor, AccessCont
         return asset.totalSupply();
     }
 
-    /// @inheritdoc IKreskoAssetIssuer
-    function convertToAssets(
-        uint256 shares
-    ) public view virtual override(ERC4626Upgradeable, IKreskoAssetIssuer) returns (uint256 assets) {
-        return super.convertToAssets(shares);
-    }
-
     function convertManyToShares(uint256[] calldata assets) external view returns (uint256[] memory shares) {
         shares = new uint256[](assets.length);
         for (uint256 i; i < assets.length; ) {
@@ -97,13 +90,6 @@ contract KreskoAssetAnchor is ERC4626Upgradeable, IKreskoAssetAnchor, AccessCont
             i++;
         }
         return assets;
-    }
-
-    /// @inheritdoc IKreskoAssetIssuer
-    function convertToShares(
-        uint256 assets
-    ) public view virtual override(ERC4626Upgradeable, IKreskoAssetIssuer) returns (uint256 shares) {
-        return super.convertToShares(assets);
     }
 
     /// @inheritdoc IKreskoAssetIssuer
@@ -138,12 +124,17 @@ contract KreskoAssetAnchor is ERC4626Upgradeable, IKreskoAssetAnchor, AccessCont
         _burn(address(asset), convertToShares(assets));
     }
 
-    /// @notice reverting function, kept to maintain compatibility with ERC4626 standard
+    /// @notice No support for direct interactions yet
+    function mint(uint256, address) public pure override(ERC4626Upgradeable, IERC4626Upgradeable) returns (uint256) {
+        revert Errors.MINT_NOT_SUPPORTED();
+    }
+
+    /// @notice No support for direct interactions yet
     function deposit(uint256, address) public pure override(ERC4626Upgradeable, IERC4626Upgradeable) returns (uint256) {
         revert Errors.DEPOSIT_NOT_SUPPORTED();
     }
 
-    /// @notice reverting function, kept to maintain compatibility with ERC4626 standard
+    /// @notice No support for direct interactions yet
     function withdraw(
         uint256,
         address,
@@ -152,7 +143,7 @@ contract KreskoAssetAnchor is ERC4626Upgradeable, IKreskoAssetAnchor, AccessCont
         revert Errors.WITHDRAW_NOT_SUPPORTED();
     }
 
-    /// @notice reverting function, kept to maintain compatibility with ERC4626 standard
+    /// @notice No support for direct interactions yet
     function redeem(uint256, address, address) public pure override(ERC4626Upgradeable, IERC4626Upgradeable) returns (uint256) {
         revert Errors.REDEEM_NOT_SUPPORTED();
     }

--- a/src/contracts/core/kresko-asset/KreskoAssetAnchor.sol
+++ b/src/contracts/core/kresko-asset/KreskoAssetAnchor.sol
@@ -73,6 +73,20 @@ contract KreskoAssetAnchor is ERC4626Upgradeable, IKreskoAssetAnchor, AccessCont
         return asset.totalSupply();
     }
 
+    /// @inheritdoc IKreskoAssetIssuer
+    function convertToAssets(
+        uint256 shares
+    ) public view virtual override(ERC4626Upgradeable, IKreskoAssetIssuer) returns (uint256 assets) {
+        return super.convertToAssets(shares);
+    }
+
+    /// @inheritdoc IKreskoAssetIssuer
+    function convertToShares(
+        uint256 assets
+    ) public view virtual override(ERC4626Upgradeable, IKreskoAssetIssuer) returns (uint256 shares) {
+        return super.convertToShares(assets);
+    }
+
     function convertManyToShares(uint256[] calldata assets) external view returns (uint256[] memory shares) {
         shares = new uint256[](assets.length);
         for (uint256 i; i < assets.length; ) {


### PR DESCRIPTION
- refactor: only allow depositing assets that are either the current fee asset or one with previously accumulated fees
- fix: forge tests due to fee asset change
- feat: add initial liquidation test
- feat: rework fee calculations
- refactor: rename and pack structs
- feat: add fee claim separately
- chore: add natspec inherit..
- chore: comment new indexs tructs a bit
- chore: remove unused lib using
- feat: add fee claim event
- refactor: slight optimization to setting new liq index
- refactor: remove feeAmount from withdraw event
- misc: test liquidation actually takes all
- fix: fee distribution hh test
- fix: hardhat test concerning scdp
- fix: override erc4626 mint with reverting like rest
